### PR TITLE
converting addresses to checksum

### DIFF
--- a/telosevm.tokenlist.json
+++ b/telosevm.tokenlist.json
@@ -93,7 +93,7 @@
     },
     {
       "chainId": 40,
-      "address": "0xfa9343c3897324496a05fc75abed6bac29f8a40f",
+      "address": "0xfA9343C3897324496A05fC75abeD6bAC29f8A40f",
       "symbol": "ETH",
       "name": "Ethereum",
       "coingeckoId": "ethereum",
@@ -104,7 +104,7 @@
     },
     {
       "chainId": 40,
-      "address": "0x818ec0a7fe18ff94269904fced6ae3dae6d6dc0b",
+      "address": "0x818ec0A7Fe18Ff94269904fCED6AE3DaE6d6dC0b",
       "symbol": "USDC",
       "name": "USD Coin",
       "coingeckoId" : "usd-coin",
@@ -115,7 +115,7 @@
     },
     {
       "chainId": 40,
-      "address": "0xefaeee334f0fd1712f9a8cc375f427d9cdd40d73",
+      "address": "0xeFAeeE334F0Fd1712f9a8cc375f427D9Cdd40d73",
       "symbol": "USDT",
       "name": "Tether Stable Coin",
       "coingeckoId" : "tether",
@@ -137,7 +137,7 @@
     },
     {
       "chainId": 40,
-      "address": "0x7c598c96d02398d89fbcb9d41eab3df0c16f227d",
+      "address": "0x7C598c96D02398d89FbCb9d41Eab3DF0C16F227D",
       "symbol": "AVAX",
       "name": "Avalanche",
       "coingeckoId" : "avalanche-2",
@@ -159,7 +159,7 @@
     },
     {
       "chainId": 40,
-      "address": "0x2c78f1b70ccf63cdee49f9233e9faa99d43aa07e",
+      "address": "0x2C78f1b70Ccf63CDEe49F9233e9fAa99D43AA07e",
       "symbol": "BNB",
       "name": "Binance Coin",
       "coingeckoId" : "binancecoin",


### PR DESCRIPTION
AVAX, USDT, USDC, and other well-known tokens have their address expressed as lowercase when they should be expressed in a valid checksum

# Fixes [#316](https://github.com/telosnetwork/telos-wallet/issues/316)

## Description
I'm fetching the balances from the new indexer and I'm experimenting with some problems due to the fact that some tokens had their address expressed as lowercase instead of valid checksum.
